### PR TITLE
Clarify the license as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2020 Mark Murnane, Jason Spriggs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version='0.0.1',
     description="It's a potato.",
     long_description="""Track shifts, sell badges, and more.""",
-    license="GPLv3",
+    license="MIT",
     author='Mark Murnane',
     author_email='mark@hackafe.net',
     url='https://github.com/magfest/tuber',


### PR DESCRIPTION
This pull request clarifies the license as being MIT, and cleans up an incorrect reference to it being GPL in the setup.py. I'm setting each current contributor as a reviewer on this pull request, and by approving this pull request we can establish agreement to accept this as the license.