### PR TITLE
Fixes to allow CI to run in forked Repos

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
+      - id: lowercase-repo-name
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
@@ -21,7 +25,7 @@ jobs:
           context: "./backend"
           target: test
           load: true
-          tags: ghcr.io/${{ github.repository }}-backend:latest
+          tags: ghcr.io/${{ steps.lowercase-repo-name.outputs.lowercase }}-backend:latest
 
       - name: Run Tests
         run: docker compose run backend pytest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -29,3 +29,5 @@ jobs:
 
       - name: Run Tests
         run: docker compose run backend pytest
+        env:
+          REPO_NAME: ${{ steps.lowercase-repo-name.outputs.lowercase }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build: ./backend
     ports:
       - 8080:8080
-    image: ghcr.io/magfest/tuber-backend:latest
+    image: ghcr.io/${REPO_NAME:-magfest/tuber}-backend:latest
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
Previously, forks that had a capital letter in the name (e.g. Erik-vdg/tuber) did not build the container directly in the backend github action. Additionally, hardcoding of the test container name to magfest/tuber prevented CI from working correctly.

This PR fixes both issues, allowing backend CI tests to now work correctly in forke.