### PR TITLE
Fix Code Coverage generation and submission to codecov

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,8 +26,21 @@ jobs:
           target: test
           load: true
           tags: ghcr.io/${{ steps.lowercase-repo-name.outputs.lowercase }}-backend:latest
-
       - name: Run Tests
-        run: docker compose run backend pytest
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/cov
+          sudo chown -R 1000:1000 $GITHUB_WORKSPACE/cov
+          sudo chmod g+s $GITHUB_WORKSPACE/cov
+          docker compose run \
+          --volume $GITHUB_WORKSPACE/cov:/cov \
+          -u 1000 \
+          backend sh -c \
+          "coverage run --data-file=/cov/.coverage -m pytest tests/ && coverage xml --data-file=/cov/.coverage -o /cov/coverage.xml"
         env:
           REPO_NAME: ${{ steps.lowercase-repo-name.outputs.lowercase }}
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
+        with:
+          files: cov/coverage.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tuber.egg-info/
 venv/
 *.sh
 scripts/cache/
+cov/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/bitbyt3r/Tuber/package/tuber/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/bitbyt3r/Tuber/package/tuber/)
 [![Heroku CI Status](https://tuber-ci-badge.herokuapp.com/last.svg)](https://dashboard.heroku.com/pipelines/6ebd065d-db02-419d-80bd-6406f271d992/tests)
-[![codecov](https://codecov.io/gh/magfest/tuber/branch/master/graph/badge.svg)](https://codecov.io/gh/magfest/tuber)
+[![codecov](https://codecov.io/gh/magfest/tuber/branch/main/graph/badge.svg)](https://codecov.io/gh/magfest/tuber)
 [![Read the Docs](https://img.shields.io/readthedocs/magfest-tuber)](https://magfest-tuber.readthedocs.io/en/latest/)
 
 [![ci-backend](https://github.com/magfest/tuber/actions/workflows/ci-backend.yaml/badge.svg)](https://github.com/magfest/tuber/tree/main/.github/workflows/ci-backend.yaml)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:alpine as build
 WORKDIR /app
 
 RUN apk update && \
-    apk add --no-cache postgresql-dev gcc python3-dev musl-dev g++ && \
+    apk add --no-cache postgresql-dev gcc python3-dev musl-dev g++ make && \
     pip3 install flask && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,12 +29,15 @@ EXPOSE 8080
 
 COPY entrypoint.sh entrypoint.sh
 CMD /bin/sh entrypoint.sh
-RUN adduser -D tuber
+RUN addgroup --gid 1000 tuber && \
+    adduser -D tuber -u 1000 --ingroup tuber 
 
 FROM build as test
 RUN apk update && \
     apk add --no-cache linux-headers postgresql && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /tuber/cov && \
+    chown -R tuber:tuber /tuber/cov
 COPY pyproject.toml pyproject.toml
 RUN pip install .[test]
 COPY tests tests

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,7 +34,7 @@ test = [
     "pytest",
     "pytest-postgresql",
     "psycopg",
-    "coverage",
+    "coverage[toml]",
     "fakeredis"
 ]
 
@@ -51,6 +51,37 @@ mypkg = [
     "migrations/*",
     "migrations/**/*",
     "static/*"
+]
+
+[tool.coverage.run]
+branch = true
+dynamic_context = "test_function"
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    'pragma: no cover',
+
+    # Don't complain about missing debug-only code:
+    'def __repr__',
+    'if self\.debug',
+
+    # Don't complain if tests don't hit defensive assertion code:
+    'raise AssertionError',
+    'raise NotImplementedError',
+
+    # Don't complain if non-runnable code isn't run:
+    'if 0:',
+    'if __name__ == .__main__.:',
+
+    # Don't complain about abstract methods, they aren't run:
+    '@(abc\.)?abstractmethod',
+]
+ignore_errors = true
+skip_empty = true
+omit = [
+    "*/tests/*"
 ]
 
 [build-system]


### PR DESCRIPTION
Coverage file generation occurs within the docker compose environment,
    so we need to make changes to the CI workflow so that permissions
    line up between the container and the environment.

README file now links to the main branch coverage badge instead of the
    defunct master branch.

Fix: Error in CI layer when installing python requires make to run
    successfully. Added to container.